### PR TITLE
command: pip install Pillow

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ venv ❯ python3 -m django --version
 (venv) $ pip install isort
 (venv) $ pip install mypy
 (venv) $ pip install bandit
+
+# ImageFieldを使えるようにするため
+(venv) $ python -m pip install Pillow
 ```
 
 ## .vscode/settings.json を設定


### PR DESCRIPTION
To resolve the following error

venv ❯ python manage.py runserver
ERRORS:
snsapp.SnsModel.snsimage: (fields.E210) Cannot use ImageField because Pillow is not installed.
        HINT: Get Pillow at https://pypi.org/project/Pillow/ or run command "python -m pip install Pillow".